### PR TITLE
Add support for extracting values of specific tagged struct fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ go get github.com/intelligentpos/structextract
 	//NamesFromTag will return an array of the tag value for the given tag, map[string]interface{}
 	//["field_1_db","field_2_db","field_3_db"]
 	tagnames, _ := extract.NamesFromTag("db")
-	
+
+
+    //ValuesFromTag will return an array of the values of the fields with the give tag
+    //["value 1", "value 2", true]
+    valuesFromTag, _ := extract.ValuesFromTag("db")
+
 
 	//FieldValueMap will return a map of field name to value, map[string]interface{}
 	//{"Field1":"value 1","Field2":"value 2","Field3":true,"Field4":123}

--- a/extract.go
+++ b/extract.go
@@ -78,6 +78,27 @@ func (e *Extractor) Values() (out []interface{}, err error) {
 	return
 }
 
+//ValuesFromTag returns an interface array with all the values of fields with the given tag
+func (e *Extractor) ValuesFromTag(tag string) (out []interface{}, err error) {
+
+	if err := e.isValidStruct(); err != nil {
+		return nil, err
+	}
+
+	s := reflect.ValueOf(e.StructAddr).Elem()
+	for i := 0; i < s.NumField(); i++ {
+		if isIgnored(s.Type().Field(i).Name, e.ignoredFields) {
+			continue
+		}
+		if _, ok := s.Type().Field(i).Tag.Lookup(tag); ok {
+			out = append(out, s.Field(i).Interface())
+		}
+
+	}
+
+	return
+}
+
 // FieldValueMap returns a string to interface map,
 // key: field as defined on the struct
 // value: the value of the field

--- a/extract_test.go
+++ b/extract_test.go
@@ -113,7 +113,7 @@ func TestExtractor_Values_Invalid_Struct(t *testing.T) {
 }
 
 func TestExtractor_ValuesFromTag(t *testing.T) {
-	ext := fakeData()
+	ext := fakeData().IgnoreField("Field4")
 	exp := []interface{}{
 		"hello",
 		"world",
@@ -127,6 +127,16 @@ func TestExtractor_ValuesFromTag(t *testing.T) {
 
 	if !reflect.DeepEqual(res, exp) {
 		t.FailNow()
+	}
+}
+
+func TestExtractor_ValuesFromTag_Invalid_Struct(t *testing.T) {
+	test := []string{"fail", "fail2"}
+	ext := New(&test)
+
+	_, err := ext.ValuesFromTag("json")
+	if err == nil {
+		t.Fatal("Passed value is not a valid struct")
 	}
 }
 

--- a/extract_test.go
+++ b/extract_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 type testStruct struct {
-	Field1 string      `json:"field_1"`
-	Field2 string      `json:"field_2"`
+	Field1 string      `json:"field_1" db:"field1"`
+	Field2 string      `json:"field_2" db:"field2"`
 	Field3 bool        `json:"field_3"`
 	Field4 interface{} `json:"field_4"`
 }
@@ -110,6 +110,24 @@ func TestExtractor_Values_Invalid_Struct(t *testing.T) {
 		t.Fatal("Passed value is not a valid struct")
 	}
 
+}
+
+func TestExtractor_ValuesFromTag(t *testing.T) {
+	ext := fakeData()
+	exp := []interface{}{
+		"hello",
+		"world",
+	}
+	res, _ := ext.ValuesFromTag("db")
+
+	expectedLength := len(exp)
+	if len(res) != expectedLength {
+		t.Fatalf("Number of values do not match: expected:%d, got:%d", expectedLength, len(res))
+	}
+
+	if !reflect.DeepEqual(res, exp) {
+		t.FailNow()
+	}
 }
 
 func TestExtractor_FieldValueMap(t *testing.T) {


### PR DESCRIPTION
The reason for this is that I've seen structs that represent entities which have fields that are not tagged as "db". When you insert in the db from Go code you have to ignore these fields. Instead of ignoring them you just get what you want by using `ValuesFromTag(tag)`