### PR TITLE
Implemented TagMapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ go get github.com/intelligentpos/structextract
 	//FieldValueFromTagMap will return a map of tag value to value, map[string]interface{}
 	//{"field1":"value 1","field2":"value 2","field3":true,"field4":123}
 	tagmap, _ := extract.FieldValueFromTagMap("json")
+
+        // Mapping between different tags
+	//{"field1":"field_1_db","field2":"field_2_db","field3":"field_3_db"}
+        mapping, _ := extract.TagMapping("json", "db")
+
 	
 ```
 #### Ignore Fields


### PR DESCRIPTION
When doing partial updates (PATCH requests), I find that it'd be nice to have a way to easily map fields from one tag to another for a given struct. Thus I did this. If you feel as though this is not necessary, feel free to decline the PR and I'll move this code into my `utils` package.
Original issue - https://github.com/intelligentpos/structextract/issues/7