### PR TITLE
Let golint fail CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 script:
   - go test -v -covermode=count -coverprofile=coverage.out
   - go vet -v ./...
-  - golint
+  - golint -set_exit_status $(glide novendor)
   
 after_script:
   - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN


### PR DESCRIPTION
Currently, `golint` will not fail the travis build. This PR would change that if `golint` complains, builds would fail.