### PR TITLE
Changeset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,60 @@ A sample example that we use the structextract with [Squirrel](https://github.co
   }
 ```
 
+
+#### Changesets and partial updates
+Implementing idiomatic PATCH routes in Go is not particularly simple. But with
+structextract, one can take a `map[string]interface{}` and apply it to an
+existing user defined struct. 
+
+```go
+	type Sample struct {
+		Name string `json:"name"`
+		Age  int    `json:"age" db:"date_of_birth"`
+	}
+
+	updateMap := map[string]interface{}{
+		"age": 4,
+	}
+
+	s := Sample{
+		"John",
+		3,
+	}
+
+	se := structextract.New(&s)
+
+	updatedStruct, _ := se.ApplyMap(updateMap)
+
+	fmt.Printf("new age - %d", updatedStruct.Age)
+
+```
+
+Likewise, the same struct can be remapped to be applied as a changeset to a row
+in SQL.
+
+```go
+	type Sample struct {
+		Name string `json:"name"`
+		Age  int    `json:"age" db:"date_of_birth"`
+	}
+
+	updateMap := map[string]interface{}{
+		"age": 4,
+    "garbage": "data",
+	}
+
+	s := Sample{
+		"John",
+		3,
+	}
+
+	se := structextract.New(&s)
+
+  // GetChangesetForTag will remove invalid key value pairs
+  // and change the keys to the specified one in the tag.
+  // If no tag is specified, the keys will be the field names.
+	sqlMap, err := se.GetChangesetForTag(updateMap, "json", "db")
+
+  fmt.Printf("%v", sqlMap)
+```

--- a/extract.go
+++ b/extract.go
@@ -239,10 +239,10 @@ func (e *Extractor) GetChangesetForTag(data map[string]interface{}, inputTag, ou
 	return
 }
 
-// ApplyMap takes a map of arbitrary values and tries to apply them to a
-// struct, matching keys with the given input tag. If the input tag is empty,
-// the key will be matched against the field name
-func (e *Extractor) ApplyMap(data map[string]interface{}, inputTag string) (interface{}, error) {
+// ApplyJSONMap a map of arbitrary values and json tags as keys and tries
+// to apply them to a struct. This function is not mutative, the original struct will remain unchanged
+// but a new struct of the same type with the changes applied to it will be returned.
+func (e *Extractor) ApplyJSONMap(data map[string]interface{}) (interface{}, error) {
 	err := e.isValidStruct()
 	if err != nil {
 		return nil, err
@@ -253,15 +253,9 @@ func (e *Extractor) ApplyMap(data map[string]interface{}, inputTag string) (inte
 	fields := e.fields(s)
 	for _, field := range fields {
 
-		var inputFieldTag string
-		var ok bool
-		if inputTag == "" {
-			inputFieldTag = field.name
-		} else {
-			inputFieldTag, ok = field.tags.Lookup(inputTag)
-			if !ok {
-				continue
-			}
+		inputFieldTag, ok := field.tags.Lookup("json")
+		if !ok {
+			continue
 		}
 
 		_, ok = data[inputFieldTag]

--- a/extract.go
+++ b/extract.go
@@ -239,8 +239,10 @@ func (e *Extractor) GetChangesetForTag(data map[string]interface{}, inputTag, ou
 	return
 }
 
-// ApplyChanges takes a map of arbitrary values and tries to apply them to a struct.
-func (e *Extractor) ApplyChanges(data map[string]interface{}, inputTag string) (interface{}, error) {
+// ApplyMap takes a map of arbitrary values and tries to apply them to a
+// struct, matching keys with the given input tag. If the input tag is empty,
+// the key will be matched against the field name
+func (e *Extractor) ApplyMap(data map[string]interface{}, inputTag string) (interface{}, error) {
 	err := e.isValidStruct()
 	if err != nil {
 		return nil, err

--- a/extract_test.go
+++ b/extract_test.go
@@ -468,3 +468,209 @@ func TestEmbeddedStructs_togglingBehaviour(t *testing.T) {
 		t.Fatalf("expected to get 2 values when using embedded struct")
 	}
 }
+
+type TestPartialUpgrade struct {
+	Name  string `json:"name"`
+	Age   int    `json:"age"`
+	Score int    `json:"score"`
+}
+
+func TestPartialUpdate(t *testing.T) {
+
+	existing := TestPartialUpgrade{
+		"Alistair", 3, 13,
+	}
+
+	update := map[string]interface{}{
+		"age":             4,
+		"unrelated_value": "some value",
+		"name":            "Boris",
+	}
+
+	ext := New(&existing).IgnoreField("Name")
+
+	maybeUpdated, err := ext.ApplyMap(update, "json")
+	if err != nil {
+		t.Fatalf("failed to apply changes: %s", err)
+	}
+
+	updated, ok := maybeUpdated.(*TestPartialUpgrade)
+	if !ok {
+		t.Fatalf("couldn't cast returned value to 'test'")
+	}
+
+	if updated.Age != 4 {
+		t.Fatalf("expected age to be 4, got %d", updated.Age)
+	}
+
+	if updated.Name != "Alistair" {
+		t.Fatalf("expected name to be Alistair, got %s", updated.Name)
+	}
+}
+
+func TestPartialUpdateWihtoutTag(t *testing.T) {
+
+	existing := TestPartialUpgrade{
+		"Alistair", 3, 13,
+	}
+
+	update := map[string]interface{}{
+		"Age":            4,
+		"Name":           "Boris",
+		"UnrelatedField": "some value",
+	}
+
+	ext := New(&existing).IgnoreField("Name")
+
+	maybeUpdated, err := ext.ApplyMap(update, "")
+	if err != nil {
+		t.Fatalf("failed to apply changes: %s", err)
+	}
+
+	updated, ok := maybeUpdated.(*TestPartialUpgrade)
+	if !ok {
+		t.Fatalf("couldn't cast returned value to 'TestPartialUpgrade', value - [%v]", maybeUpdated)
+	}
+
+	if updated.Age != 4 {
+		t.Fatalf("expected age to be 4, got %d", updated.Age)
+	}
+
+	if updated.Name != "Alistair" {
+		t.Fatalf("expected name to be Alistair, got %s", updated.Name)
+	}
+}
+
+type TestEmbedded struct {
+	TestPartialUpgrade
+	ID string `json:"id"`
+}
+
+func TestEmbeddedPartialUpdate(t *testing.T) {
+	existing := TestEmbedded{
+		TestPartialUpgrade{
+			"Alistair", 3, 13,
+		},
+		"some id",
+	}
+
+	update := map[string]interface{}{
+		"Age":            4,
+		"Name":           "Boris",
+		"UnrelatedField": "some value",
+	}
+
+	ext := New(&existing).UseEmbeddedStructs(true)
+
+	maybeUpdated, err := ext.ApplyMap(update, "")
+	if err != nil {
+		t.Fatalf("failed to apply changes: %s", err)
+	}
+
+	if maybeUpdated == nil {
+		t.Fatalf("returned value is nil")
+	}
+
+	updated, ok := maybeUpdated.(*TestEmbedded)
+	if !ok {
+		t.Fatalf("couldn't cast returned value to TestEmbedded")
+	}
+
+	if updated.Age != 4 {
+		t.Fatalf("expected age to be 4, got %d", updated.Age)
+	}
+
+	if updated.Name != "Boris" {
+		t.Fatalf("expected name to be Boris, got %s", updated.Name)
+	}
+}
+
+func TestChangesetMap(t *testing.T) {
+	type TestChangeset struct {
+		Field string `json:"jsonField" db:"dbField"`
+	}
+
+	ext := New(&TestChangeset{})
+	jsonMap := map[string]interface{}{
+		"jsonField": "value",
+	}
+
+	sqlMap, err := ext.GetChangesetForTag(jsonMap, "json", "db")
+	if err != nil {
+		t.Fatalf("failed to create changeset map: %s", err)
+	}
+
+	val, ok := sqlMap["dbField"]
+	if !ok {
+		t.Fatalf("[dbField] field not found in output map")
+	}
+
+	if val != "value" {
+		t.Fatalf("expected dbField to have 'value'")
+	}
+}
+
+func TestPartialUpdateNullability(t *testing.T) {
+	type TestChangeset struct {
+		Field *string `json:"jsonField" db:"dbField"`
+	}
+
+	ext := New(&TestChangeset{})
+	jsonMap := map[string]interface{}{
+		"jsonField": nil,
+	}
+
+	sqlMap, err := ext.GetChangesetForTag(jsonMap, "json", "db")
+	if err != nil {
+		t.Fatalf("failed to create changeset map: %s", err)
+	}
+
+	val, ok := sqlMap["dbField"]
+	if !ok {
+		t.Fatalf("[dbField] field not found in output map")
+	}
+
+	if val != nil {
+		t.Fatalf("expected dbField to be nil")
+	}
+
+}
+
+func TestPartialUpdateWithNull(t *testing.T) {
+
+	type TestPartialUpgradeWithNull struct {
+		Name  string `json:"name"`
+		Age   *int   `json:"age"`
+		Score int    `json:"score"`
+	}
+	age := 3
+	existing := TestPartialUpgradeWithNull{
+		"Alistair", &age, 13,
+	}
+
+	update := map[string]interface{}{
+		"age":             nil,
+		"unrelated_value": "some value",
+		"name":            "Boris",
+	}
+
+	ext := New(&existing).IgnoreField("Name")
+
+	maybeUpdated, err := ext.ApplyMap(update, "json")
+	if err != nil {
+		t.Fatalf("failed to apply changes: %s", err)
+	}
+
+	updated, ok := maybeUpdated.(*TestPartialUpgradeWithNull)
+	if !ok {
+		t.Fatalf("couldn't cast returned value to 'test'")
+	}
+
+	if updated.Age != nil {
+		t.Fatalf("expected age to be nil, got %v", updated.Age)
+	}
+
+	if updated.Name != "Alistair" {
+		t.Fatalf("expected name to be Alistair, got %s", updated.Name)
+	}
+}

--- a/extract_test.go
+++ b/extract_test.go
@@ -489,7 +489,7 @@ func TestPartialUpdate(t *testing.T) {
 
 	ext := New(&existing).IgnoreField("Name")
 
-	maybeUpdated, err := ext.ApplyMap(update, "json")
+	maybeUpdated, err := ext.ApplyJSONMap(update)
 	if err != nil {
 		t.Fatalf("failed to apply changes: %s", err)
 	}
@@ -508,42 +508,10 @@ func TestPartialUpdate(t *testing.T) {
 	}
 }
 
-func TestPartialUpdateWihtoutTag(t *testing.T) {
-
-	existing := TestPartialUpgrade{
-		"Alistair", 3, 13,
-	}
-
-	update := map[string]interface{}{
-		"Age":            4,
-		"Name":           "Boris",
-		"UnrelatedField": "some value",
-	}
-
-	ext := New(&existing).IgnoreField("Name")
-
-	maybeUpdated, err := ext.ApplyMap(update, "")
-	if err != nil {
-		t.Fatalf("failed to apply changes: %s", err)
-	}
-
-	updated, ok := maybeUpdated.(*TestPartialUpgrade)
-	if !ok {
-		t.Fatalf("couldn't cast returned value to 'TestPartialUpgrade', value - [%v]", maybeUpdated)
-	}
-
-	if updated.Age != 4 {
-		t.Fatalf("expected age to be 4, got %d", updated.Age)
-	}
-
-	if updated.Name != "Alistair" {
-		t.Fatalf("expected name to be Alistair, got %s", updated.Name)
-	}
-}
-
 type TestEmbedded struct {
 	TestPartialUpgrade
-	ID string `json:"id"`
+	ID           string `json:"id"`
+	NonJSONField string
 }
 
 func TestEmbeddedPartialUpdate(t *testing.T) {
@@ -552,17 +520,18 @@ func TestEmbeddedPartialUpdate(t *testing.T) {
 			"Alistair", 3, 13,
 		},
 		"some id",
+		"non-json field",
 	}
 
 	update := map[string]interface{}{
-		"Age":            4,
-		"Name":           "Boris",
+		"age":            4,
+		"name":           "Boris",
 		"UnrelatedField": "some value",
 	}
 
 	ext := New(&existing).UseEmbeddedStructs(true)
 
-	maybeUpdated, err := ext.ApplyMap(update, "")
+	maybeUpdated, err := ext.ApplyJSONMap(update)
 	if err != nil {
 		t.Fatalf("failed to apply changes: %s", err)
 	}
@@ -656,7 +625,7 @@ func TestPartialUpdateWithNull(t *testing.T) {
 
 	ext := New(&existing).IgnoreField("Name")
 
-	maybeUpdated, err := ext.ApplyMap(update, "json")
+	maybeUpdated, err := ext.ApplyJSONMap(update)
 	if err != nil {
 		t.Fatalf("failed to apply changes: %s", err)
 	}


### PR DESCRIPTION
As described in the readme, this allows structextract to create a map of updates and apply partial updates to strcuts. This should allow us to easily implement PATCH routes. This PR depends on https://github.com/intelligentpos/structextract/pull/9. 